### PR TITLE
Fix #19

### DIFF
--- a/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/DubboApiDocsAnnotationScanner.java
+++ b/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/DubboApiDocsAnnotationScanner.java
@@ -120,16 +120,20 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
             }
             boolean async;
             String apiVersion;
+            String apiGroup;
             if (apiModuleClass.isAnnotationPresent(Service.class)) {
                 Service dubboService = apiModuleClass.getAnnotation(Service.class);
                 async = dubboService.async();
                 apiVersion = dubboService.version();
+                apiGroup = dubboService.group();
             } else {
                 DubboService dubboService = apiModuleClass.getAnnotation(DubboService.class);
                 async = dubboService.async();
                 apiVersion = dubboService.version();
+                apiGroup = dubboService.group();
             }
             apiVersion = applicationContext.getEnvironment().resolvePlaceholders(apiVersion);
+            apiGroup = applicationContext.getEnvironment().resolvePlaceholders(apiGroup);
             ModuleCacheItem moduleCacheItem = new ModuleCacheItem();
             DubboApiDocsCache.addApiModule(moduleAnn.apiInterface().getCanonicalName(), moduleCacheItem);
             //module name
@@ -138,6 +142,8 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
             moduleCacheItem.setModuleClassName(moduleAnn.apiInterface().getCanonicalName());
             //module version
             moduleCacheItem.setModuleVersion(apiVersion);
+            //module group
+            moduleCacheItem.setModuleGroup(apiGroup);
 
             Method[] apiModuleMethods = apiModuleClass.getMethods();
             // API basic information list in module cache
@@ -145,7 +151,7 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
             moduleCacheItem.setModuleApiList(moduleApiList);
             for (Method method : apiModuleMethods) {
                 if (method.isAnnotationPresent(ApiDoc.class)) {
-                    processApiDocAnnotation(method, moduleApiList, moduleAnn, async, moduleCacheItem, apiVersion);
+                    processApiDocAnnotation(method, moduleApiList, moduleAnn, async, moduleCacheItem, apiVersion, apiGroup);
                 }
             }
         });
@@ -153,7 +159,7 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
     }
 
     private void processApiDocAnnotation(Method method, List<ApiCacheItem> moduleApiList, ApiModule moduleAnn,
-                                         boolean async, ModuleCacheItem moduleCacheItem, String apiVersion) {
+                                         boolean async, ModuleCacheItem moduleCacheItem, String apiVersion, String apiGroup) {
 
         ApiDoc dubboApi = method.getAnnotation(ApiDoc.class);
 
@@ -168,6 +174,8 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
         apiListItem.setDescription(dubboApi.description());
         //API version
         apiListItem.setApiVersion(apiVersion);
+        //API group
+        apiListItem.setApiGroup(apiGroup);
         //Description of API return data
         apiListItem.setApiRespDec(dubboApi.responseClassDescription());
 
@@ -185,6 +193,7 @@ public class DubboApiDocsAnnotationScanner implements ApplicationListener<Applic
         apiParamsAndResp.setApiName(method.getName());
         apiParamsAndResp.setApiDocName(dubboApi.value());
         apiParamsAndResp.setApiVersion(apiVersion);
+        apiParamsAndResp.setApiGroup(apiGroup);
         apiParamsAndResp.setApiRespDec(dubboApi.responseClassDescription());
         apiParamsAndResp.setDescription(dubboApi.description());
         apiParamsAndResp.setApiModelClass(moduleCacheItem.getModuleClassName());

--- a/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/beans/ApiCacheItem.java
+++ b/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/beans/ApiCacheItem.java
@@ -31,6 +31,8 @@ public class ApiCacheItem {
 
     private String apiVersion;
 
+    private String apiGroup;
+
     private String description;
 
     private String apiRespDec;
@@ -121,5 +123,13 @@ public class ApiCacheItem {
 
     public void setMethodParamInfo(String methodParamInfo) {
         this.methodParamInfo = methodParamInfo;
+    }
+
+    public String getApiGroup() {
+        return apiGroup;
+    }
+
+    public void setApiGroup(String apiGroup) {
+        this.apiGroup = apiGroup;
     }
 }

--- a/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/beans/ModuleCacheItem.java
+++ b/dubbo-api-docs/dubbo-api-docs-core/src/main/java/org/apache/dubbo/apidocs/core/beans/ModuleCacheItem.java
@@ -29,6 +29,8 @@ public class ModuleCacheItem {
 
     private String moduleVersion;
 
+    private String moduleGroup;
+
     private List<ApiCacheItem> moduleApiList;
 
     public String getModuleDocName() {
@@ -61,5 +63,13 @@ public class ModuleCacheItem {
 
     public void setModuleApiList(List<ApiCacheItem> moduleApiList) {
         this.moduleApiList = moduleApiList;
+    }
+
+    public String getModuleGroup() {
+        return moduleGroup;
+    }
+
+    public void setModuleGroup(String moduleGroup) {
+        this.moduleGroup = moduleGroup;
     }
 }

--- a/dubbo-api-docs/dubbo-api-docs-examples/examples-provider/src/main/java/org/apache/dubbo/apidocs/examples/api/impl/QuickStartDemoImpl.java
+++ b/dubbo-api-docs/dubbo-api-docs-examples/examples-provider/src/main/java/org/apache/dubbo/apidocs/examples/api/impl/QuickStartDemoImpl.java
@@ -40,7 +40,7 @@ import java.util.Map;
  *
  * @date 2020/12/23 17:21
  */
-@DubboService(version = "${demo.apiversion.quickstart}")
+@DubboService(version = "${demo.apiversion.quickstart}", group = "demoGroup")
 @ApiModule(value = "quick start demo", apiInterface = IQuickStartDemo.class)
 public class QuickStartDemoImpl implements IQuickStartDemo {
 

--- a/dubbo-api-docs/dubbo-api-docs-examples/examples-provider/src/main/resources/application.yml
+++ b/dubbo-api-docs/dubbo-api-docs-examples/examples-provider/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
 dubbo:
   registry:
     address: zookeeper://127.0.0.1:2181
+#    group: DEFAULT_GROUP
   provider:
     timeout: 2000
     filter: metrics
@@ -33,8 +34,10 @@ dubbo:
     name: dubbo-api-docs-example-provider
   metadata-report:
     address: zookeeper://127.0.0.1:2181
+#    group: DEFAULT_GROUP
   config-center:
     address: zookeeper://127.0.0.1:2181
+#    group: DEFAULT_GROUP
   metrics:
     port: ${dubbo.protocol.port}
     protocol: dubbo


### PR DESCRIPTION
## What is the purpose of the change

fix #19 of api docs bug

## Brief changelog

The parsing of group parameter is added, and group is added to the cache

## Verifying this change

Add group attribute in Dubbo annotation, you can see the interface group in the interface document module of dubbo admin and call the interface successfully