### PR TITLE
optimize peakEwmaLoadbalance

### DIFF
--- a/dubbo-cluster-extensions/dubbo-cluster-loadbalance-peakewma/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.LoadBalance
+++ b/dubbo-cluster-extensions/dubbo-cluster-loadbalance-peakewma/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.cluster.LoadBalance
@@ -1,0 +1,1 @@
+peakewma=org.apache.dubbo.rpc.cluster.loadbalance.PeakEwmaLoadBalance

--- a/dubbo-cluster-extensions/dubbo-cluster-loadbalance-peakewma/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalanceTest.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-loadbalance-peakewma/src/test/java/org/apache/dubbo/rpc/cluster/loadbalance/PeakEwmaLoadBalanceTest.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.rpc.cluster.loadbalance;
 
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.RpcStatus;
+import org.apache.dubbo.rpc.model.ApplicationModel;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,7 @@ public class PeakEwmaLoadBalanceTest extends LoadBalanceBaseTest {
 
     private Callable<Boolean> getTask(boolean needShake) {
         PeakEwmaLoadBalance lb = new PeakEwmaLoadBalance();
+        lb.setApplicationModel(ApplicationModel.defaultModel());
         return () -> {
             boolean needShakeTemp = needShake;
             for (int i = 0; i < INVOKE_NUM; i++) {


### PR DESCRIPTION
## What is the purpose of the change

1.Supplementary configuration file
2.optimize peakEwmaLoadbalance

## Brief changelog

### 1.Supplementary configuration file.
### 2.replace deprecated api.
### 3.handle double precision problem.
### 4.change `successAverageRt` to `allInvokeRt`
- When some invokers always invoke timeout or throw other exception,it's successAverageRt is  zero all the time.
- It will not perform well when provider invoker fail in fast (rt=0),which I think it's not loadbalance's duty([kubernetes](https://github.com/kubernetes/ingress-nginx/issues/5540)).

