### PR TITLE
fix(#10209): fixed the bug that 'application discovery use http proto…

### DIFF
--- a/dubbo-rpc-extensions/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
+++ b/dubbo-rpc-extensions/dubbo-rpc-http/src/main/java/org/apache/dubbo/rpc/protocol/http/HttpProtocol.java
@@ -140,7 +140,7 @@ public class HttpProtocol extends AbstractProxyProtocol {
             }
             return invocation;
         });
-        String key = url.setProtocol("http").toIdentityString();
+        String key = url.toIdentityString();
         if (isGeneric) {
             key = key + "/" + GENERIC_KEY;
         }


### PR DESCRIPTION
fixed the bug that 'application discovery use http protocol throw NPE'

## What is the purpose of the change

fixed this bug which link is "https://github.com/apache/dubbo/issues/10209"

## Brief changelog

fixed the bug that 'application discovery use http protocol throw NPE'

## Verifying this change

fixed the bug that 'application discovery use http protocol throw NPE'

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [ ] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
