### PR TITLE
[Feature]Support redirect call remote

### DIFF
--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/AddressSpecifyClusterInterceptor.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/AddressSpecifyClusterInterceptor.java
@@ -45,7 +45,7 @@ public class AddressSpecifyClusterInterceptor implements ClusterInterceptor {
             nodeInvoker.setAccessible(true);
             Object clusterObj = nodeInvoker.get(clusterInvoker);
             if (clusterObj instanceof AbstractClusterInvoker) {
-                //禁用本地service校验
+                // Disable the existence check of the local cluster service
                 Directory<?> directory = ((AbstractClusterInvoker<?>)clusterObj).getDirectory();
                 if (directory instanceof RegistryDirectory) {
                     RegistryDirectory<?> rd = (RegistryDirectory<?>) directory;

--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressRouter.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressRouter.java
@@ -48,6 +48,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.MONITOR_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PROTOCOL_KEY;
 import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
 
 
@@ -233,7 +234,7 @@ public class UserSpecifiedAddressRouter<T> extends AbstractRouter {
     }
 
 
-    public <T> URL buildAddress(List<Invoker<T>> invokers, Address address, URL consumerUrl) {
+    public URL buildAddress(List<Invoker<T>> invokers, Address address, URL consumerUrl) {
         if (!invokers.isEmpty()) {
             URL template = invokers.iterator().next().getUrl();
             template = template.setHost(address.getIp());
@@ -252,10 +253,11 @@ public class UserSpecifiedAddressRouter<T> extends AbstractRouter {
     }
 
     private URL copyConsumerUrl(URL url, String ip, int port, Map<String, String> parameters) {
+        String protocol = url.getParameter(PROTOCOL_KEY, DUBBO);
         return URLBuilder.from(url)
                 .setHost(ip)
                 .setPort(port)
-                .setProtocol(url.getProtocol() == null ? DUBBO : url.getProtocol())
+                .setProtocol(protocol)
                 .setPath(url.getPath())
                 .clearParameters()
                 .addParameters(parameters)
@@ -264,7 +266,7 @@ public class UserSpecifiedAddressRouter<T> extends AbstractRouter {
     }
 
     public URL rebuildAddress(Address address, URL consumerUrl) {
-        URL url = (URL) address.getUrlAddress();
+        URL url = address.getUrlAddress();
         Map<String, String> parameters = new HashMap<>(url.getParameters());
         parameters.put(VERSION_KEY, consumerUrl.getParameter(VERSION_KEY, "0.0.0"));
         parameters.put(GROUP_KEY, consumerUrl.getParameter(GROUP_KEY));


### PR DESCRIPTION
## What is the purpose of the change

Issue Number: #185 

## Brief changelog

Because the service address is specified using a custom extension, the invoker verification can be used to close the local cluster.
dubbo3 provides the switch dubbo.router.should-fail-fast, which can directly turn off the verification,
And 2.7.18 is not provided.
The attribute forbidden provides the same function, but is automatically judged by the size of the available invoker. In 2.7.x, use reflection to modify the forbidden value, so as to achieve the effect similar to dubbo.router.should-fail-fast.

At the same time, fix a build address bug, the newly created Url, the consumer protocol obtained through url.getProtocol(), will report an error "no corresponding extension point(Protocol)"

![image](https://user-images.githubusercontent.com/38374721/208621485-b4568f71-3c8f-4e28-be82-6d2dc146b7dd.png)

![image](https://user-images.githubusercontent.com/38374721/208621547-18e0ea7a-3387-4b9b-9475-9417f718d4e7.png)
