### PR TITLE
add gateway mode

### DIFF
--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/pom.xml
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>dubbo-common</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-rpc-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 

--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/Address.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/Address.java
@@ -34,6 +34,8 @@ public class Address implements Serializable {
     // address - priority: 1
     private URL urlAddress;
     private boolean needToCreate = false;
+    // if true will convert param type to JavaBeanDescriptor
+    private boolean gatewayMode = false;
 
     public Address(String ip, int port) {
         this.ip = ip;
@@ -41,13 +43,14 @@ public class Address implements Serializable {
         this.urlAddress = null;
     }
 
-    /**
-     * disableRetry default value is true, will disable failover
-     */
     public Address(String ip, int port, boolean needToCreate) {
-        this.ip = ip;
-        this.port = port;
+        this(ip, port);
         this.needToCreate = needToCreate;
+    }
+
+    public Address(String ip, int port, boolean needToCreate, boolean gatewayMode) {
+        this(ip, port, needToCreate);
+        this.gatewayMode = gatewayMode;
     }
 
     public Address(URL address) {
@@ -86,6 +89,14 @@ public class Address implements Serializable {
 
     public void setNeedToCreate(boolean needToCreate) {
         this.needToCreate = needToCreate;
+    }
+
+    public boolean isGatewayMode() {
+        return gatewayMode;
+    }
+
+    public void setGatewayMode(boolean gatewayMode) {
+        this.gatewayMode = gatewayMode;
     }
 
     @Override

--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressUtil.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-common/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressUtil.java
@@ -57,6 +57,8 @@ public class UserSpecifiedAddressUtil {
             return;
         }
         Class<?>[] parameterTypes = invocation.getParameterTypes();
+        invocation.setObjectAttachment("originParameterType", getDesc(parameterTypes));
+
         Arrays.fill(parameterTypes, JavaBeanDescriptor.class);
 
         Object[] arguments = invocation.getArguments();
@@ -69,4 +71,7 @@ public class UserSpecifiedAddressUtil {
         ((RpcInvocation) invocation).setCompatibleParamSignatures(Stream.of(parameterTypes).map(Class::getName).toArray(String[]::new));
     }
 
+    private static String[] getDesc(Class<?>[] parameterTypes) {
+        return Arrays.stream(parameterTypes).map(Class::getName).toArray(String[]::new);
+    }
 }

--- a/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressRouter.java
+++ b/dubbo-cluster-extensions/dubbo-cluster-specify-address-dubbo2/src/main/java/org/apache/dubbo/rpc/cluster/specifyaddress/UserSpecifiedAddressRouter.java
@@ -16,29 +16,33 @@
  */
 package org.apache.dubbo.rpc.cluster.specifyaddress;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.URLBuilder;
-import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
-import org.apache.dubbo.common.beanutil.JavaBeanSerializeUtil;
 import org.apache.dubbo.common.extension.ExtensionLoader;
 import org.apache.dubbo.common.logger.Logger;
 import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.threadpool.manager.ExecutorRepository;
 import org.apache.dubbo.common.utils.ClassUtils;
 import org.apache.dubbo.common.utils.CollectionUtils;
-import org.apache.dubbo.common.utils.ReflectUtils;
 import org.apache.dubbo.common.utils.StringUtils;
-import org.apache.dubbo.rpc.*;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Protocol;
+import org.apache.dubbo.rpc.RpcException;
 import org.apache.dubbo.rpc.cluster.router.AbstractRouter;
 import org.apache.dubbo.rpc.cluster.specifyaddress.common.InvokerCache;
-
-import java.util.*;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
 
 import static org.apache.dubbo.common.constants.CommonConstants.DUBBO;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;

--- a/dubbo-gateway-extensions/dubbo-gateway-consumer/pom.xml
+++ b/dubbo-gateway-extensions/dubbo-gateway-consumer/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-gateway-extensions</artifactId>
+        <groupId>org.apache.dubbo.extensions</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-gateway-consumer</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-rpc-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/dubbo-gateway-extensions/dubbo-gateway-consumer/src/main/java/org/apache/dubbo/gateway/consumer/filter/OmnSerFilter.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-consumer/src/main/java/org/apache/dubbo/gateway/consumer/filter/OmnSerFilter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.gateway.consumer.filter;
+
+import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
+import org.apache.dubbo.common.beanutil.JavaBeanSerializeUtil;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.ReflectUtils;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+
+@Activate(group = CommonConstants.CONSUMER)
+public class OmnSerFilter implements Filter, Filter.Listener {
+
+    private final static Logger logger = LoggerFactory.getLogger(OmnSerFilter.class);
+
+    public static final String name = "specifyAddress";
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
+
+        Object address = invocation.get(name);
+        if (address != null) {
+            convertParameterTypeToJavaBeanDescriptor(invocation);
+        }
+        return invoker.invoke(invocation);
+    }
+
+
+    @Override
+    public void onResponse(Result appResponse, Invoker<?> invoker, Invocation inv) {
+
+        Object resData = appResponse.getValue();
+        if (resData == null) {
+            return;
+        }
+
+        if (ReflectUtils.isPrimitives(resData.getClass())) {
+            return;
+        }
+        generalizeJbdParameter(appResponse.getValue());
+    }
+
+    @Override
+    public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
+
+    }
+
+
+    private void generalizeJbdParameter(Object resData) {
+        // public field
+        for (Field field : resData.getClass().getDeclaredFields()) {
+            try {
+                field.setAccessible(true);
+                Object fieldValue = field.get(resData);
+                if (fieldValue instanceof JavaBeanDescriptor) {
+                    field.set(resData, JavaBeanSerializeUtil.deserialize((JavaBeanDescriptor) fieldValue));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+
+    public static void convertParameterTypeToJavaBeanDescriptor(Invocation invocation) {
+        if (!(invocation instanceof RpcInvocation)) {
+            logger.warn("Non-RpcInvocation type, gateway mode does not take effect, type:" + invocation.getClass().getName());
+            return;
+        }
+        Class<?>[] parameterTypes = invocation.getParameterTypes();
+        invocation.setObjectAttachment("originParameterType", getDesc(parameterTypes));
+
+        Arrays.fill(parameterTypes, JavaBeanDescriptor.class);
+
+        Object[] arguments = invocation.getArguments();
+        for (int i = 0; i < arguments.length; i++) {
+            JavaBeanDescriptor jbdArg = JavaBeanSerializeUtil.serialize(arguments[i]);
+            arguments[i] = jbdArg;
+        }
+
+        ((RpcInvocation) invocation).setParameterTypesDesc(ReflectUtils.getDesc(parameterTypes));
+        ((RpcInvocation) invocation).setCompatibleParamSignatures(Stream.of(parameterTypes).map(Class::getName).toArray(String[]::new));
+    }
+
+    private static String[] getDesc(Class<?>[] parameterTypes) {
+        return Arrays.stream(parameterTypes).map(Class::getName).toArray(String[]::new);
+    }
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-consumer/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
+++ b/dubbo-gateway-extensions/dubbo-gateway-consumer/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+omnSer=org.apache.dubbo.gateway.consumer.filter.OmnSerFilter

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/pom.xml
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-gateway-extensions</artifactId>
+        <groupId>org.apache.dubbo.extensions</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-gateway-provider</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>3.2.0-beta.6-SNAPSHOT</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/ConfigDeployListener.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/ConfigDeployListener.java
@@ -1,0 +1,34 @@
+package org.apache.dubbo.gateway.provider;
+
+import org.apache.dubbo.common.deploy.ApplicationDeployListener;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+
+import static org.apache.dubbo.common.constants.CommonConstants.EXCEPTION_PROCESSOR_KEY;
+
+public class ConfigDeployListener implements ApplicationDeployListener {
+
+    @Override
+    public void onStarting(ApplicationModel scopeModel) {
+
+    }
+
+    @Override
+    public void onStarted(ApplicationModel scopeModel) {
+        ApplicationModel.defaultModel().getCurrentConfig().getParameters().put(EXCEPTION_PROCESSOR_KEY,"snf");
+    }
+
+    @Override
+    public void onStopping(ApplicationModel scopeModel) {
+
+    }
+
+    @Override
+    public void onStopped(ApplicationModel scopeModel) {
+
+    }
+
+    @Override
+    public void onFailure(ApplicationModel scopeModel, Throwable cause) {
+
+    }
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/OmnipotentCommonConstants.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/OmnipotentCommonConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.gateway.provider;
+
+public interface OmnipotentCommonConstants {
+
+    //save orgin group when service is omn
+    String ORIGIN_GROUP_KEY = "originGroup";
+
+    String ORIGIN_GENERIC_PARAMETER_TYPES = "originGenericParameterTypes";
+
+    String $INVOKE_OMN = "$invokeOmn";
+
+    String ORIGIN_PATH_KEY = "originPath";
+
+    String ORIGIN_METHOD_KEY = "originMethod";
+
+    String ORIGIN_VERSION_KEY = "originVersion";
+
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/OmnipotentService.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/OmnipotentService.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.gateway.provider;
+
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.service.GenericException;
+import org.apache.dubbo.rpc.service.GenericService;
+
+/**
+ * A more general server-side generalization service than {@link GenericService}
+ * Any type of interface can be accepted
+ *
+ * @since 3.2.0
+ */
+public interface OmnipotentService {
+
+    /**
+     * Generic invocation
+     *
+     * @param invocation  New construction point invocation, including original service, method and other information
+     * @return Custom object
+     * @throws GenericException potential exception thrown from the invocation
+     */
+    Object $invokeOmn(Invocation invocation) throws GenericException;
+
+
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/ServiceNotFoundExceptionProcessor.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/ServiceNotFoundExceptionProcessor.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.dubbo.gateway.provider;
+
+import org.apache.dubbo.common.serialize.Cleanable;
+import org.apache.dubbo.common.serialize.ObjectInput;
+import org.apache.dubbo.remoting.ExceptionProcessor;
+import org.apache.dubbo.remoting.RetryHandleException;
+import org.apache.dubbo.remoting.ServiceNotFoundException;
+import org.apache.dubbo.remoting.exchange.ExchangeChannel;
+import org.apache.dubbo.remoting.exchange.Request;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.protocol.dubbo.DecodeableRpcInvocation;
+
+import java.util.Map;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DEFAULT_VERSION;
+import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.INTERFACE_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.METHOD_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+
+/**
+ * <p>The default exception handler interrupts the return of the client error message by throwing a {@link RetryHandleException},
+ * so that there is a chance to enter the decode process again.
+ * <p>Then handle the {@link ServiceNotFoundException} through server-side generalization {@link OmnipotentService}
+ * (different from the original generalization, which can accept any interface)
+ *
+ * @since 3.2.0
+ */
+public class ServiceNotFoundExceptionProcessor implements ExceptionProcessor {
+
+    private DecodeableRpcInvocation rpcInvocation;
+
+    private static final String DEFAULT_OMNIPOTENT_SERVICE = OmnipotentService.class.getName();
+
+    @Override
+    public void setContext(Object context) {
+        if (context instanceof DecodeableRpcInvocation) {
+            this.rpcInvocation = (DecodeableRpcInvocation) context;
+        }
+    }
+
+    @Override
+    public boolean shouldHandleError(Throwable data) {
+        return data instanceof ServiceNotFoundException;
+    }
+
+    @Override
+    public String wrapAndHandleException(ExchangeChannel channel, Request req) throws RetryHandleException {
+        Object data = req.getData();
+        if (!(data instanceof DecodeableRpcInvocation)) {
+            return null;
+        }
+        DecodeableRpcInvocation invocation = (DecodeableRpcInvocation) data;
+
+        invocation.setAttachment(OmnipotentCommonConstants.ORIGIN_PATH_KEY, invocation.getAttachment(PATH_KEY));
+        // Replace serviceName in req with omn
+        invocation.setAttachment(PATH_KEY, DEFAULT_OMNIPOTENT_SERVICE);
+        invocation.setAttachment(INTERFACE_KEY, DEFAULT_OMNIPOTENT_SERVICE);
+
+        // version
+        invocation.setAttachment(OmnipotentCommonConstants.ORIGIN_VERSION_KEY, invocation.getAttachment(VERSION_KEY));
+        invocation.setAttachment(VERSION_KEY, DEFAULT_VERSION);
+
+        // method
+        invocation.setAttachment(OmnipotentCommonConstants.ORIGIN_METHOD_KEY, invocation.getMethodName());
+        invocation.setAttachment(METHOD_KEY, OmnipotentCommonConstants.$INVOKE_OMN);
+        invocation.setMethodName(OmnipotentCommonConstants.$INVOKE_OMN);
+        invocation.setParameterTypes(new Class<?>[]{Invocation.class});
+
+        // Reset the decoded flag to continue the decoding process again
+        invocation.resetHasDecoded();
+
+        throw new RetryHandleException(channel, "Service not found:" + invocation.getAttachment(OmnipotentCommonConstants.ORIGIN_PATH_KEY) + ", " + invocation.getAttachment(OmnipotentCommonConstants.ORIGIN_METHOD_KEY));
+    }
+
+    @Override
+    public void customPts(Class<?>[] pts) {
+        if (rpcInvocation != null) {
+            rpcInvocation.setAttachment(OmnipotentCommonConstants.ORIGIN_GENERIC_PARAMETER_TYPES, pts);
+        }
+    }
+
+    @Override
+    public void customAttachment(Map<String, Object> map) {
+
+        if (rpcInvocation == null) {
+            return;
+        }
+        // Omn needs to use the default path, version and group,
+        // and the original value starts with origin to save the variable
+        map.remove(PATH_KEY);
+        map.remove(VERSION_KEY);
+        if (map.containsKey(GROUP_KEY)) {
+            map.put(OmnipotentCommonConstants.ORIGIN_GROUP_KEY, map.get(GROUP_KEY));
+            map.remove(GROUP_KEY);
+        }
+    }
+
+    @Override
+    public void cleanUp() {
+
+        if (rpcInvocation == null) {
+            return;
+        }
+        ObjectInput objectInput = rpcInvocation.getObjectInput();
+        if ((objectInput instanceof Cleanable)) {
+            ((Cleanable) objectInput).cleanup();
+        }
+        rpcInvocation.setObjectInput(null);
+    }
+
+
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/filter/OmnSerFilter.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/filter/OmnSerFilter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.gateway.provider.filter;
+
+import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
+import org.apache.dubbo.common.beanutil.JavaBeanSerializeUtil;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.common.utils.ReflectUtils;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+
+import java.lang.reflect.Field;
+
+
+@Activate(group = CommonConstants.CONSUMER)
+public class OmnSerFilter implements Filter, Filter.Listener {
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation inv) throws RpcException {
+        return invoker.invoke(inv);
+    }
+
+
+    @Override
+    public void onResponse(Result appResponse, Invoker<?> invoker, Invocation inv) {
+
+        Object resData = appResponse.getValue();
+        if (resData == null) {
+            return;
+        }
+
+        if (ReflectUtils.isPrimitives(resData.getClass())) {
+            return;
+        }
+        generalizeJbdParameter(appResponse.getValue());
+    }
+
+    @Override
+    public void onError(Throwable t, Invoker<?> invoker, Invocation invocation) {
+
+    }
+
+
+    private void generalizeJbdParameter(Object resData) {
+        // public field
+        for (Field field : resData.getClass().getDeclaredFields()) {
+            try {
+                field.setAccessible(true);
+                Object fieldValue = field.get(resData);
+                if (fieldValue instanceof JavaBeanDescriptor) {
+                    field.set(resData, JavaBeanSerializeUtil.deserialize((JavaBeanDescriptor) fieldValue));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/filter/OmnipotentFilter.java
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/java/org/apache/dubbo/gateway/provider/filter/OmnipotentFilter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.gateway.provider.filter;
+
+import org.apache.dubbo.common.beanutil.JavaBeanAccessor;
+import org.apache.dubbo.common.beanutil.JavaBeanDescriptor;
+import org.apache.dubbo.common.beanutil.JavaBeanSerializeUtil;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.gateway.provider.OmnipotentCommonConstants;
+import org.apache.dubbo.gateway.provider.OmnipotentService;
+import org.apache.dubbo.rpc.Filter;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
+
+import static org.apache.dubbo.common.constants.CommonConstants.PATH_KEY;
+import static org.apache.dubbo.common.constants.CommonConstants.VERSION_KEY;
+
+/**
+ * Set the method name, formal parameters, and actual parameters for
+ * the invokeOmn method of the Omnipotent generalized service
+ */
+@Activate(group = CommonConstants.PROVIDER, order = -21000)
+public class OmnipotentFilter implements Filter {
+
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation inv) throws RpcException {
+
+        if (isOmnipotent(invoker.getInterface())) {
+            setOmnArgs(inv);
+            inv.getObjectAttachments().remove(OmnipotentCommonConstants.ORIGIN_GENERIC_PARAMETER_TYPES);
+            RpcContext.getServerAttachment().removeAttachment(OmnipotentCommonConstants.ORIGIN_GENERIC_PARAMETER_TYPES);
+        }
+
+        return invoker.invoke(inv);
+    }
+
+    private boolean isOmnipotent(Class<?> interfaceClass) {
+        return OmnipotentService.class.isAssignableFrom(interfaceClass);
+    }
+
+    // Restore method information before actual call
+    private void setOmnArgs(Invocation inv) {
+        Class<?>[] parameterTypes = (Class<?>[]) inv.getObjectAttachment(OmnipotentCommonConstants.ORIGIN_GENERIC_PARAMETER_TYPES, new Class<?>[]{Invocation.class});
+        Object[] arguments = inv.getArguments();
+
+        Object[] args = new Object[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            // In gateway mode, consumer has used JavaBeanDescriptor as parameter
+            if (arguments[i] instanceof JavaBeanDescriptor) {
+                args[i] = arguments[i];
+            } else {
+                args[i] = JavaBeanSerializeUtil.serialize(arguments[i], JavaBeanAccessor.METHOD);
+            }
+        }
+
+        RpcInvocation rpcInvocation = new RpcInvocation(inv);
+        // method
+        rpcInvocation.setMethodName(inv.getAttachment(OmnipotentCommonConstants.ORIGIN_METHOD_KEY));
+        rpcInvocation.setParameterTypes(parameterTypes);
+        rpcInvocation.setArguments(args);
+
+        // attachment
+        rpcInvocation.setAttachment(PATH_KEY, inv.getAttachment(OmnipotentCommonConstants.ORIGIN_PATH_KEY));
+        rpcInvocation.setAttachment(VERSION_KEY, inv.getAttachment(OmnipotentCommonConstants.ORIGIN_VERSION_KEY));
+        ((RpcInvocation) inv).setArguments(new Object[]{rpcInvocation});
+
+    }
+
+}

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.common.deploy.ApplicationDeployListener
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.common.deploy.ApplicationDeployListener
@@ -1,0 +1,1 @@
+snfConfig=gateway.consumer.ConfigDeployListener

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.remoting.ExceptionProcessor
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.remoting.ExceptionProcessor
@@ -1,0 +1,1 @@
+snf=gateway.consumer.ServiceNotFoundExceptionProcessor

--- a/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.rpc.Filter
+++ b/dubbo-gateway-extensions/dubbo-gateway-provider/src/main/resources/META-INF.dubbo.internal/org.apache.dubbo.rpc.Filter
@@ -1,0 +1,1 @@
+omnipotent=org.apache.dubbo.gateway.filter.OmnipotentFilter

--- a/dubbo-gateway-extensions/pom.xml
+++ b/dubbo-gateway-extensions/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.dubbo.extensions</groupId>
+        <artifactId>extensions-parent</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-gateway-extensions</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>dubbo-gateway-provider</module>
+        <module>dubbo-gateway-consumer</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <module>dubbo-rpc-extensions</module>
         <module>dubbo-serialization-extensions</module>
         <module>dubbo-mock-extensions</module>
+        <module>dubbo-gateway-extensions</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## What is the purpose of the change

When using the switch address function, if the specified provider does not find the service and use the serviceNotFound extension (gateway) at the same time, if the class type of the parameter does not exist in the provider, an error will be reported in the decode stage of the gateway

```java
if (pts == DubboCodec.EMPTY_CLASS_ARRAY) {
    if (!RpcUtils.isGenericCall(desc, getMethodName()) && !RpcUtils.isEcho(desc, getMethodName())) {
        throw new IllegalArgumentException("Service not found:" + path + ", " + getMethodName());
    }
    pts = ReflectUtils.desc2classArray(desc);  // class not found
}
```

## Brief changelog

use JavaBeanDescriptor as the type of arg,  so that the gateway provider can deserialize success


