### PR TITLE
[Serialization] add fury serialization framework to dubbo

### DIFF
--- a/dubbo-extensions-dependencies-bom/pom.xml
+++ b/dubbo-extensions-dependencies-bom/pom.xml
@@ -90,7 +90,7 @@
 
     <properties>
         <revision>1.0.5-SNAPSHOT</revision>
-        <dubbo.version>3.1.2</dubbo.version>
+        <dubbo.version>3.2.1</dubbo.version>
         <spring.version>5.2.9.RELEASE</spring.version>
         <spring-boot.version>2.4.1</spring-boot.version>
 
@@ -111,6 +111,7 @@
         <avro_version>1.8.2</avro_version>
         <fastjson_version>1.2.83</fastjson_version>
         <fst_version>2.48-jdk-6</fst_version>
+        <fury_version>0.2.0</fury_version>
         <gson_version>2.8.9</gson_version>
         <kryo_version>5.4.0</kryo_version>
         <kryo_serializers_version>0.45</kryo_serializers_version>
@@ -297,6 +298,11 @@
                 <groupId>de.ruedigermoeller</groupId>
                 <artifactId>fst</artifactId>
                 <version>${fst_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.furyio</groupId>
+                <artifactId>fury-core</artifactId>
+                <version>${fury_version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/dubbo-extensions-dependencies-bom/pom.xml
+++ b/dubbo-extensions-dependencies-bom/pom.xml
@@ -90,7 +90,7 @@
 
     <properties>
         <revision>1.0.5-SNAPSHOT</revision>
-        <dubbo.version>3.2.1</dubbo.version>
+        <dubbo.version>3.1.2</dubbo.version>
         <spring.version>5.2.9.RELEASE</spring.version>
         <spring-boot.version>2.4.1</spring-boot.version>
 

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.dubbo.extensions</groupId>
         <artifactId>dubbo-serialization-extensions</artifactId>
@@ -26,28 +26,31 @@ limitations under the License.
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-  <artifactId>dubbo-serialization-fury</artifactId>
+    <artifactId>dubbo-serialization-fury</artifactId>
 
-  <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dubbo.version>3.2.1</dubbo.version>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo-serialization-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.dubbo</groupId>
-      <artifactId>dubbo</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.furyio</groupId>
-      <artifactId>fury-core</artifactId>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-serialization-api</artifactId>
+            <version>${dubbo.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${dubbo.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.furyio</groupId>
+            <artifactId>fury-core</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.dubbo.extensions</groupId>
+        <artifactId>dubbo-serialization-extensions</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+  <artifactId>dubbo-serialization-fury</artifactId>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo-serialization-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.dubbo</groupId>
+      <artifactId>dubbo</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.furyio</groupId>
+      <artifactId>fury-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/BaseFurySerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/BaseFurySerialization.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/BaseFurySerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/BaseFurySerialization.java
@@ -1,0 +1,51 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.collection.Tuple2;
+import io.fury.memory.MemoryBuffer;
+import io.fury.util.LoaderBinding;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.serialize.ObjectInput;
+import org.apache.dubbo.common.serialize.ObjectOutput;
+import org.apache.dubbo.common.serialize.Serialization;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+/**
+ * Fury serialization framework integration with dubbo.
+ *
+ * @author chaokunyang
+ */
+public abstract class BaseFurySerialization implements Serialization {
+  protected abstract Tuple2<LoaderBinding, MemoryBuffer> getFury();
+
+  public ObjectOutput serialize(URL url, OutputStream output) throws IOException {
+    Tuple2<LoaderBinding, MemoryBuffer> tuple2 = getFury();
+    tuple2.f0.setClassLoader(Thread.currentThread().getContextClassLoader());
+    Fury fury = tuple2.f0.get();
+    FuryCheckerListener checkerListener = getCheckerListener(url);
+    fury.getClassResolver().setClassChecker(checkerListener.getChecker());
+    fury.getClassResolver().setSerializerFactory(checkerListener);
+    return new FuryObjectOutput(fury, tuple2.f1, output);
+  }
+
+  public ObjectInput deserialize(URL url, InputStream input) throws IOException {
+    Tuple2<LoaderBinding, MemoryBuffer> tuple2 = getFury();
+    tuple2.f0.setClassLoader(Thread.currentThread().getContextClassLoader());
+    Fury fury = tuple2.f0.get();
+    FuryCheckerListener checkerListener = getCheckerListener(url);
+    fury.getClassResolver().setClassChecker(checkerListener.getChecker());
+    return new FuryObjectInput(fury, tuple2.f1, input);
+  }
+
+  private static FuryCheckerListener getCheckerListener(URL url) {
+    return Optional.ofNullable(url)
+        .map(URL::getOrDefaultFrameworkModel)
+        .orElseGet(FrameworkModel::defaultModel)
+        .getBeanFactory()
+        .getBean(FuryCheckerListener.class);
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCheckerListener.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCheckerListener.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCheckerListener.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCheckerListener.java
@@ -1,0 +1,75 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.exception.InsecureException;
+import io.fury.resolver.AllowListChecker;
+import io.fury.serializer.Serializer;
+import io.fury.serializer.SerializerFactory;
+import java.io.Serializable;
+import java.util.Set;
+import org.apache.dubbo.common.utils.AllowClassNotifyListener;
+import org.apache.dubbo.common.utils.SerializeCheckStatus;
+import org.apache.dubbo.common.utils.SerializeSecurityManager;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+
+@SuppressWarnings("rawtypes")
+public class FuryCheckerListener implements AllowClassNotifyListener, SerializerFactory {
+  private final SerializeSecurityManager securityManager;
+  private final AllowListChecker checker;
+  private volatile boolean checkSerializable;
+
+  public FuryCheckerListener(FrameworkModel frameworkModel) {
+    checker = new AllowListChecker();
+    securityManager =
+        frameworkModel.getBeanFactory().getOrRegisterBean(SerializeSecurityManager.class);
+    securityManager.registerListener(this);
+  }
+
+  @Override
+  public void notifyPrefix(Set<String> allowedList, Set<String> disAllowedList) {
+    for (String prefix : allowedList) {
+      checker.allowClass(prefix);
+    }
+    for (String prefix : disAllowedList) {
+      checker.disallowClass(prefix);
+    }
+  }
+
+  @Override
+  public void notifyCheckStatus(SerializeCheckStatus status) {
+    switch (status) {
+      case DISABLE:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.DISABLE);
+        return;
+      case WARN:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.WARN);
+        return;
+      case STRICT:
+        checker.setCheckLevel(AllowListChecker.CheckLevel.STRICT);
+        return;
+      default:
+        throw new UnsupportedOperationException("Unsupported check level " + status);
+    }
+  }
+
+  @Override
+  public void notifyCheckSerializable(boolean checkSerializable) {
+    this.checkSerializable = checkSerializable;
+  }
+
+  public AllowListChecker getChecker() {
+    return checker;
+  }
+
+  public boolean isCheckSerializable() {
+    return checkSerializable;
+  }
+
+  @Override
+  public Serializer createSerializer(Fury fury, Class<?> cls) {
+    if (checkSerializable && !Serializable.class.isAssignableFrom(cls)) {
+      throw new InsecureException(String.format("%s is not Serializable", cls));
+    }
+    return null;
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCompatibleSerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCompatibleSerialization.java
@@ -1,0 +1,45 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.collection.Tuple2;
+import io.fury.config.CompatibleMode;
+import io.fury.memory.MemoryBuffer;
+import io.fury.memory.MemoryUtils;
+import io.fury.util.LoaderBinding;
+
+/**
+ * Fury serialization for dubbo. This integration support type forward/backward compatibility.
+ *
+ * @author chaokunyang
+ */
+public class FuryCompatibleSerialization extends BaseFurySerialization {
+  public static final byte FURY_SERIALIZATION_ID = 29;
+  private static final ThreadLocal<Tuple2<LoaderBinding, MemoryBuffer>> furyFactory =
+      ThreadLocal.withInitial(
+          () -> {
+            LoaderBinding binding =
+                new LoaderBinding(
+                    classLoader ->
+                        Fury.builder()
+                            .withRefTracking(true)
+                            .requireClassRegistration(false)
+                            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+                            .withClassLoader(classLoader)
+                            .build());
+            MemoryBuffer buffer = MemoryUtils.buffer(32);
+            return Tuple2.of(binding, buffer);
+          });
+
+  public byte getContentTypeId() {
+    return FURY_SERIALIZATION_ID;
+  }
+
+  public String getContentType() {
+    return "fury/compatible";
+  }
+
+  @Override
+  protected Tuple2<LoaderBinding, MemoryBuffer> getFury() {
+    return furyFactory.get();
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCompatibleSerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryCompatibleSerialization.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectInput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectInput.java
@@ -1,0 +1,106 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import org.apache.dubbo.common.serialize.ObjectInput;
+
+@SuppressWarnings("unchecked")
+public class FuryObjectInput implements ObjectInput {
+  private final Fury fury;
+  private final MemoryBuffer buffer;
+  private final InputStream input;
+
+  public FuryObjectInput(Fury fury, MemoryBuffer buffer, InputStream input) {
+    this.fury = fury;
+    this.buffer = buffer;
+    this.input = input;
+  }
+
+  @Override
+  public Object readObject() {
+    return fury.deserializeJavaObjectAndClass(input);
+  }
+
+  @Override
+  public <T> T readObject(Class<T> cls) {
+    return (T) readObject();
+  }
+
+  @Override
+  public <T> T readObject(Class<T> cls, Type type) {
+    return (T) readObject();
+  }
+
+  @Override
+  public boolean readBool() throws IOException {
+    readBytes(buffer.getHeapMemory(), 1);
+    return buffer.getBoolean(0);
+  }
+
+  @Override
+  public byte readByte() throws IOException {
+    readBytes(buffer.getHeapMemory(), 1);
+    return buffer.get(0);
+  }
+
+  @Override
+  public short readShort() throws IOException {
+    readBytes(buffer.getHeapMemory(), 2);
+    return buffer.getShort(0);
+  }
+
+  @Override
+  public int readInt() throws IOException {
+    readBytes(buffer.getHeapMemory(), 4);
+    return buffer.getInt(0);
+  }
+
+  @Override
+  public long readLong() throws IOException {
+    readBytes(buffer.getHeapMemory(), 8);
+    return buffer.getLong(0);
+  }
+
+  @Override
+  public float readFloat() throws IOException {
+    readBytes(buffer.getHeapMemory(), 4);
+    return buffer.getFloat(0);
+  }
+
+  @Override
+  public double readDouble() throws IOException {
+    readBytes(buffer.getHeapMemory(), 8);
+    return buffer.getDouble(0);
+  }
+
+  @Override
+  public String readUTF() throws IOException {
+    int size = readInt();
+    buffer.readerIndex(0);
+    buffer.ensure(size);
+    readBytes(buffer.getHeapMemory(), size);
+    if (buffer.readBoolean()) {
+      return fury.readJavaString(buffer);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public byte[] readBytes() throws IOException {
+    int size = readInt();
+    byte[] bytes = new byte[size];
+    readBytes(bytes, size);
+    return bytes;
+  }
+
+  private void readBytes(byte[] bytes, int size) throws IOException {
+    int off = 0;
+    while (off != size) {
+      off += input.read(bytes, off, size - off);
+    }
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectInput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectInput.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectOutput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectOutput.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectOutput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryObjectOutput.java
@@ -1,0 +1,91 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.dubbo.common.serialize.ObjectOutput;
+
+/**
+ * Fury implementation for {@link ObjectOutput}.
+ *
+ * @author chaokunyang
+ */
+public class FuryObjectOutput implements ObjectOutput {
+  private final Fury fury;
+  private final MemoryBuffer buffer;
+  private final OutputStream output;
+
+  public FuryObjectOutput(Fury fury, MemoryBuffer buffer, OutputStream output) {
+    this.fury = fury;
+    this.buffer = buffer;
+    this.output = output;
+  }
+
+  public void writeObject(Object obj) {
+    fury.serializeJavaObjectAndClass(output, obj);
+  }
+
+  public void writeBool(boolean v) throws IOException {
+    buffer.unsafePutBoolean(0, v);
+    output.write(buffer.getHeapMemory(), 0, 1);
+  }
+
+  public void writeByte(byte v) throws IOException {
+    buffer.unsafePut(0, v);
+    output.write(buffer.getHeapMemory(), 0, 1);
+  }
+
+  public void writeShort(short v) throws IOException {
+    buffer.unsafePutShort(0, v);
+    output.write(buffer.getHeapMemory(), 0, 2);
+  }
+
+  public void writeInt(int v) throws IOException {
+    buffer.unsafePutInt(0, v);
+    output.write(buffer.getHeapMemory(), 0, 4);
+  }
+
+  public void writeLong(long v) throws IOException {
+    buffer.unsafePutLong(0, v);
+    output.write(buffer.getHeapMemory(), 0, 8);
+  }
+
+  public void writeFloat(float v) throws IOException {
+    buffer.unsafePutFloat(0, v);
+    output.write(buffer.getHeapMemory(), 0, 4);
+  }
+
+  public void writeDouble(double v) throws IOException {
+    buffer.unsafePutDouble(0, v);
+    output.write(buffer.getHeapMemory(), 0, 8);
+  }
+
+  public void writeUTF(String v) throws IOException {
+    // avoid `writeInt` overwrite sting data.
+    buffer.writerIndex(4);
+    if (v != null) {
+      buffer.writeBoolean(true);
+      fury.writeJavaString(buffer, v);
+    } else {
+      buffer.writeBoolean(false);
+    }
+    int size = buffer.writerIndex() - 4;
+    writeInt(size);
+    output.write(buffer.getHeapMemory(), 4, size);
+  }
+
+  public void writeBytes(byte[] v) throws IOException {
+    writeInt(v.length);
+    output.write(v);
+  }
+
+  public void writeBytes(byte[] v, int off, int len) throws IOException {
+    writeInt(len);
+    output.write(v, off, len);
+  }
+
+  public void flushBuffer() throws IOException {
+    output.flush();
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryScopeModelInitializer.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryScopeModelInitializer.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryScopeModelInitializer.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FuryScopeModelInitializer.java
@@ -1,0 +1,21 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import org.apache.dubbo.common.beans.factory.ScopeBeanFactory;
+import org.apache.dubbo.rpc.model.ApplicationModel;
+import org.apache.dubbo.rpc.model.FrameworkModel;
+import org.apache.dubbo.rpc.model.ModuleModel;
+import org.apache.dubbo.rpc.model.ScopeModelInitializer;
+
+public class FuryScopeModelInitializer implements ScopeModelInitializer {
+  @Override
+  public void initializeFrameworkModel(FrameworkModel frameworkModel) {
+    ScopeBeanFactory beanFactory = frameworkModel.getBeanFactory();
+    beanFactory.registerBean(FuryCheckerListener.class);
+  }
+
+  @Override
+  public void initializeApplicationModel(ApplicationModel applicationModel) {}
+
+  @Override
+  public void initializeModuleModel(ModuleModel moduleModel) {}
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FurySerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FurySerialization.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.dubbo.common.serialize.fury.dubbo;
 
 import io.fury.Fury;

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FurySerialization.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/java/org/apache/dubbo/common/serialize/fury/dubbo/FurySerialization.java
@@ -1,0 +1,44 @@
+package org.apache.dubbo.common.serialize.fury.dubbo;
+
+import io.fury.Fury;
+import io.fury.collection.Tuple2;
+import io.fury.memory.MemoryBuffer;
+import io.fury.memory.MemoryUtils;
+import io.fury.util.LoaderBinding;
+
+/**
+ * Fury serialization for dubbo. This integration doesn't allow type inconsistency between
+ * serialization and deserialization peer.
+ *
+ * @author chaokunyang
+ */
+public class FurySerialization extends BaseFurySerialization {
+  public static final byte FURY_SERIALIZATION_ID = 28;
+  private static final ThreadLocal<Tuple2<LoaderBinding, MemoryBuffer>> furyFactory =
+      ThreadLocal.withInitial(
+          () -> {
+            LoaderBinding binding =
+                new LoaderBinding(
+                    classLoader ->
+                        Fury.builder()
+                            .withRefTracking(true)
+                            .requireClassRegistration(false)
+                            .withClassLoader(classLoader)
+                            .build());
+            MemoryBuffer buffer = MemoryUtils.buffer(32);
+            return Tuple2.of(binding, buffer);
+          });
+
+  public byte getContentTypeId() {
+    return FURY_SERIALIZATION_ID;
+  }
+
+  public String getContentType() {
+    return "fury/consistent";
+  }
+
+  @Override
+  protected Tuple2<LoaderBinding, MemoryBuffer> getFury() {
+    return furyFactory.get();
+  }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.serialize.Serialization
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.common.serialize.Serialization
@@ -1,0 +1,2 @@
+fury=org.apache.dubbo.common.serialize.fury.dubbo.FurySerialization
+fury-compatible=org.apache.dubbo.common.serialize.fury.dubbo.FuryCompatibleSerialization

--- a/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.model.ScopeModelInitializer
+++ b/dubbo-serialization-extensions/dubbo-serialization-fury/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.model.ScopeModelInitializer
@@ -1,0 +1,2 @@
+fury=org.apache.dubbo.common.serialize.fury.dubbo.FuryScopeModelInitializer
+fury-compatible=org.apache.dubbo.common.serialize.fury.dubbo.FuryScopeModelInitializer

--- a/dubbo-serialization-extensions/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/optimized/KryoObjectInput2.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-kryo/src/main/java/org/apache/dubbo/common/serialize/kryo/optimized/KryoObjectInput2.java
@@ -146,7 +146,7 @@ public class KryoObjectInput2 implements ObjectInput, Cleanable {
     }
 
     @Override
-    public Object readEvent() throws IOException, ClassNotFoundException {
+    public String readEvent() throws IOException, ClassNotFoundException {
         try {
             return kryo.readObjectOrNull(input, String.class);
         } catch (KryoException e) {

--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectInput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufJsonObjectInput.java
@@ -149,7 +149,7 @@ public class GenericProtobufJsonObjectInput implements ObjectInput {
     }
 
     @Override
-    public Object readEvent() throws IOException, ClassNotFoundException {
+    public String readEvent() throws IOException, ClassNotFoundException {
         String eventData = readUTF();
         if (eventData.equals(MOCK_HEARTBEAT_EVENT)) {
             eventData = HEARTBEAT_EVENT;

--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectInput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/GenericProtobufObjectInput.java
@@ -124,7 +124,7 @@ public class GenericProtobufObjectInput implements ObjectInput {
     }
 
     @Override
-    public Object readEvent() throws IOException {
+    public String readEvent() throws IOException {
         String eventData = readUTF();
         if (eventData.equals(MOCK_HEARTBEAT_EVENT)) {
             eventData = HEARTBEAT_EVENT;

--- a/dubbo-serialization-extensions/pom.xml
+++ b/dubbo-serialization-extensions/pom.xml
@@ -36,6 +36,7 @@
         <module>dubbo-serialization-gson</module>
         <module>dubbo-serialization-fst</module>
         <module>dubbo-serialization-fastjson</module>
+        <module>dubbo-serialization-fury</module>
         <module>dubbo-serialization-avro</module>
         <module>dubbo-serialization-msgpack</module>
         <module>dubbo-serialization-native-hession</module>


### PR DESCRIPTION
## What is the purpose of the change
Fury is a blazing fast serialization powered by jit and zero-copy. Fury features at:
-Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian without modifying any code, but 10~100x faster, which can greatly improve the efficiency of high-performance RPC calls, data transfer and object persistence.
- JDK serialization API such as `writeObject/readObject/writeReplace/readResolve/readObjectNoData/Externalizable` 100% compatible.
- JDK8~21 supported, Interactivity between jdk versions. The data serialized by jdk8 can be deserialized by jdk21
- JDK 17+ record supported.
- 10X faster than kryo in jdk17 record: https://github.com/chaokunyang/fury-benchmarks#fury-vs-kryo-in-jdk17
![image](https://github.com/apache/dubbo-spi-extensions/assets/12445254/fff583e4-0b36-42db-998c-cf37b1bb0f6c)

- Fastest serialization framework in https://github.com/eishay/jvm-serializers/wiki

This PR add the fury integration to dubbo repo for better consistency with dubbo serialization-api

## Related issue
https://github.com/apache/dubbo/issues/13160
