### PR TITLE
 [Dubbo-267] Fix protobuf type lose field when deepCopy inJvmInvoker …

### DIFF
--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/pom.xml
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/pom.xml
@@ -47,6 +47,12 @@ limitations under the License.
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${dubbo.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.16.3</version>

--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/ProtobufParamDeepCopyUtil.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/java/org/apache/dubbo/common/serialize/protobuf/support/ProtobufParamDeepCopyUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.protobuf.support;
+
+import static org.apache.dubbo.common.constants.LoggerCodeConstants.PROTOCOL_ERROR_DESERIALIZE;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
+import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.rpc.protocol.injvm.DefaultParamDeepCopyUtil;
+import org.apache.dubbo.rpc.protocol.injvm.ParamDeepCopyUtil;
+
+public class ProtobufParamDeepCopyUtil implements ParamDeepCopyUtil {
+    private static final ErrorTypeAwareLogger logger = LoggerFactory.getErrorTypeAwareLogger(DefaultParamDeepCopyUtil.class);
+
+    private ParamDeepCopyUtil delegate;
+
+    public ProtobufParamDeepCopyUtil(ParamDeepCopyUtil delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <T> T copy(URL url, Object src, Class<T> targetClass) {
+        boolean isProtobufTypeSupported = ProtobufUtils.isSupported(targetClass);
+        if(isProtobufTypeSupported){
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                ProtobufUtils.serialize(src, outputStream);
+
+                try (ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
+                    T deserialize = ProtobufUtils.deserialize(inputStream, targetClass);
+                    return deserialize;
+                } catch (IOException e) {
+                    logger.error(PROTOCOL_ERROR_DESERIALIZE, "", "", "Unable to deep copy parameter to target class.", e);
+                }
+
+            } catch (Throwable e) {
+                logger.error(PROTOCOL_ERROR_DESERIALIZE, "", "", "Unable to deep copy parameter to target class.", e);
+            }
+
+            if (src.getClass().equals(targetClass)) {
+                return (T) src;
+            } else {
+                return null;
+            }
+        }
+        return delegate.copy(url, src, targetClass);
+    }
+}

--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.injvm.ParamDeepCopyUtil
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.rpc.protocol.injvm.ParamDeepCopyUtil
@@ -1,0 +1,1 @@
+protobufDeepUtil=org.apache.dubbo.common.serialize.protobuf.support.ProtobufParamDeepCopyUtil

--- a/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/ProtobufParamDeepCopyUtilTest.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-protobuf/src/test/java/org/apache/dubbo/common/serialize/protobuf/support/ProtobufParamDeepCopyUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.serialize.protobuf.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.serialize.protobuf.support.model.GooglePB;
+import org.apache.dubbo.rpc.protocol.injvm.DefaultParamDeepCopyUtil;
+import org.apache.dubbo.rpc.protocol.injvm.ParamDeepCopyUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+public class ProtobufParamDeepCopyUtilTest {
+    private ParamDeepCopyUtil paramDeepCopyUtil;
+
+    @BeforeEach
+    public void setUp() {
+        URL url = mockURL();
+        this.paramDeepCopyUtil = url.getOrDefaultFrameworkModel().getExtensionLoader(ParamDeepCopyUtil.class)
+            .getExtension(url.getParameter(CommonConstants.INJVM_COPY_UTIL_KEY, DefaultParamDeepCopyUtil.NAME));
+    }
+
+    @Test
+    public void testProtobufDeepCopy() throws InvalidProtocolBufferException {
+        ProtobufUtils.marshaller(GooglePB.PBRequestType.getDefaultInstance());
+        GooglePB.PhoneNumber phoneNumber = GooglePB.PhoneNumber.newBuilder()
+            .setNumber("134123781291").build();
+        List<GooglePB.PhoneNumber> phoneNumberList = new ArrayList<>();
+        phoneNumberList.add(phoneNumber);
+        Map<String, GooglePB.PhoneNumber> phoneNumberMap = new HashMap<>();
+        phoneNumberMap.put("someUser", phoneNumber);
+        GooglePB.PBRequestType request = GooglePB.PBRequestType.newBuilder()
+            .setAge(15).setCash(10).setMoney(16.0).setNum(100L)
+            .addAllPhone(phoneNumberList).putAllDoubleMap(phoneNumberMap).build();
+        GooglePB.PBRequestType copyResult = paramDeepCopyUtil.copy(mockURL(), request, GooglePB.PBRequestType.class);
+        String jsonString = ProtobufUtils.serializeJson(request);
+        String jsonString2 = ProtobufUtils.serializeJson(copyResult);
+        assertEquals(jsonString, jsonString2);
+        assertNotEquals(System.identityHashCode(request), System.identityHashCode(copyResult));
+        List<GooglePB.PhoneNumber> copyPhoneList = copyResult.getPhoneList();
+        Map<String, GooglePB.PhoneNumber> copyDoubleMap = copyResult.getDoubleMap();
+        assertNotEquals(System.identityHashCode(phoneNumberList.get(0)), System.identityHashCode(copyPhoneList.get(0)));
+        assertNotEquals(System.identityHashCode(phoneNumberMap.get("someUser")), System.identityHashCode(copyDoubleMap.get("someUser")));
+    }
+
+    URL mockURL() {
+        URL url = new URL("dubbo", "localhost", 20880);
+        return url;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

修复INJVM模式下 Protobuf对象，不能被正常深度拷贝
问题复现
```java
@Test
    public void testProtobufDeepCopy1() throws InvalidProtocolBufferException {
        SerializeSecurityManager serializeSecurityManager = FrameworkModel.defaultModel().getBeanFactory().getOrRegisterBean(SerializeSecurityManager.class);
        serializeSecurityManager.setCheckStatus(SerializeCheckStatus.WARN);
        ProtobufUtils.marshaller(GooglePB.PBRequestType.getDefaultInstance());
        ParamDeepCopyUtil paramDeepCopyUtil = new DefaultParamDeepCopyUtil();
        GooglePB.PhoneNumber phoneNumber = GooglePB.PhoneNumber.newBuilder()
            .setNumber("134123781291").build();
        List<GooglePB.PhoneNumber> phoneNumberList = new ArrayList<>();
        phoneNumberList.add(phoneNumber);
        Map<String, GooglePB.PhoneNumber> phoneNumberMap = new HashMap<>();
        phoneNumberMap.put("someUser", phoneNumber);
        GooglePB.PBRequestType request = GooglePB.PBRequestType.newBuilder()
            .setAge(15).setCash(10).setMoney(16.0).setNum(100L)
            .addAllPhone(phoneNumberList).putAllDoubleMap(phoneNumberMap).build();
        GooglePB.PBRequestType copyResult = paramDeepCopyUtil.copy(mockURL(), request, GooglePB.PBRequestType.class);
        String jsonString = ProtobufUtils.serializeJson(request);
        String jsonString2 = ProtobufUtils.serializeJson(copyResult);
        // hession 的深度拷贝会导致  jsonString2 = {}
        assertEquals(jsonString, jsonString2);
    }
```
## Brief changelog

dubbo-spi-extensions\dubbo-serialization-extensions\dubbo-serialization-protobuf\src\test\java\org\apache\dubbo\common\serialize\protobuf\support\ProtobufParamDeepCopyUtilTest.java

dubbo-spi-extensions\dubbo-serialization-extensions\dubbo-serialization-protobuf\src\main\resources\META-INF\dubbo\internal\org.apache.dubbo.rpc.protocol.injvm.ParamDeepCopyUtil

## Verifying this change

增加一个wraper 扩展，假如继承protobuf的接口，则使用另外的序列化器。  

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [x] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).