### PR TITLE
fix: redis connection do not close and return to connection pool

### DIFF
--- a/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/ClusterRedisClient.java
+++ b/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/ClusterRedisClient.java
@@ -75,7 +75,10 @@ public class ClusterRedisClient extends AbstractRedisClient implements RedisClie
         for (JedisPool jedisPool : poolMap.values()) {
             Jedis jedis = jedisPool.getResource();
             if (jedis.isConnected()) {
+                jedisPool.returnResource(jedis);
                 return true;
+            } else {
+                jedisPool.returnResource(jedis);
             }
         }
         return false;
@@ -98,7 +101,7 @@ public class ClusterRedisClient extends AbstractRedisClient implements RedisClie
         for (JedisPool jedisPool : nodes.values()) {
             Jedis jedis = jedisPool.getResource();
             result.addAll(scan(jedis, pattern));
-            jedis.close();
+            jedisPool.returnResource(jedis);
         }
         return result;
     }

--- a/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/MonoRedisClient.java
+++ b/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/MonoRedisClient.java
@@ -55,7 +55,7 @@ public class MonoRedisClient extends AbstractRedisClient implements RedisClient 
     public Long publish(String channel, String message) {
         Jedis jedis = jedisPool.getResource();
         Long result = jedis.publish(channel, message);
-        jedis.close();
+        jedisPool.returnResource(jedis);
         return result;
     }
 
@@ -63,7 +63,7 @@ public class MonoRedisClient extends AbstractRedisClient implements RedisClient 
     public boolean isConnected() {
         Jedis jedis = jedisPool.getResource();
         boolean connected = jedis.isConnected();
-        jedis.close();
+        jedisPool.returnResource(jedis);
         return connected;
     }
 
@@ -76,7 +76,7 @@ public class MonoRedisClient extends AbstractRedisClient implements RedisClient 
     public Long hdel(String key, String... fields) {
         Jedis jedis = jedisPool.getResource();
         Long result = jedis.hdel(key, fields);
-        jedis.close();
+        jedisPool.returnResource(jedis);
         return result;
     }
 
@@ -84,7 +84,7 @@ public class MonoRedisClient extends AbstractRedisClient implements RedisClient 
     public Set<String> scan(String pattern) {
         Jedis jedis = jedisPool.getResource();
         Set<String> result = super.scan(jedis, pattern);
-        jedis.close();
+        jedisPool.returnResource(jedis);
         return result;
     }
 
@@ -92,7 +92,7 @@ public class MonoRedisClient extends AbstractRedisClient implements RedisClient 
     public Map<String, String> hgetAll(String key) {
         Jedis jedis = jedisPool.getResource();
         Map<String, String> result = jedis.hgetAll(key);
-        jedis.close();
+        jedisPool.returnResource(jedis);
         return result;
     }
 

--- a/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/SentinelRedisClient.java
+++ b/dubbo-remoting-extensions/dubbo-remoting-redis/src/main/java/org/apache/dubbo/remoting/redis/jedis/SentinelRedisClient.java
@@ -58,7 +58,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public Long hset(String key, String field, String value) {
         Jedis jedis = sentinelPool.getResource();
         Long result = jedis.hset(key, field, value);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -66,7 +66,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public Long publish(String channel, String message) {
         Jedis jedis = sentinelPool.getResource();
         Long result = jedis.publish(channel, message);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -74,7 +74,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public boolean isConnected() {
         Jedis jedis = sentinelPool.getResource();
         boolean result = jedis.isConnected();
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -87,7 +87,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public Long hdel(String key, String... fields) {
         Jedis jedis = sentinelPool.getResource();
         Long result = jedis.hdel(key, fields);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -95,7 +95,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public Set<String> scan(String pattern) {
         Jedis jedis = sentinelPool.getResource();
         Set<String> result = scan(jedis, pattern);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -103,7 +103,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public Map<String, String> hgetAll(String key) {
         Jedis jedis = sentinelPool.getResource();
         Map<String, String> result = jedis.hgetAll(key);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
         return result;
     }
 
@@ -111,7 +111,7 @@ public class SentinelRedisClient extends AbstractRedisClient implements RedisCli
     public void psubscribe(JedisPubSub jedisPubSub, String... patterns) {
         Jedis jedis = sentinelPool.getResource();
         jedis.psubscribe(jedisPubSub, patterns);
-        jedis.close();
+        sentinelPool.returnResource(jedis);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

try to fix #73 and apache/dubbo#1677

Get Jedis from pool don't need to close connection after using, just return the connection to pool that we can reused the connection in next time.

## Brief changelog

redis connection do not close and return to connection pool

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [ ] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
