### PR TITLE
Bump jetcd vertsion from 0.5.7 to 0.7.7

### DIFF
--- a/dubbo-configcenter-extensions/dubbo-configcenter-etcd/pom.xml
+++ b/dubbo-configcenter-extensions/dubbo-configcenter-etcd/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/dubbo-configcenter-extensions/dubbo-configcenter-etcd/src/main/java/org/apache/dubbo/configcenter/support/etcd/EtcdDynamicConfiguration.java
+++ b/dubbo-configcenter-extensions/dubbo-configcenter-etcd/src/main/java/org/apache/dubbo/configcenter/support/etcd/EtcdDynamicConfiguration.java
@@ -22,6 +22,8 @@ import org.apache.dubbo.common.config.configcenter.ConfigChangeType;
 import org.apache.dubbo.common.config.configcenter.ConfigChangedEvent;
 import org.apache.dubbo.common.config.configcenter.ConfigurationListener;
 import org.apache.dubbo.common.config.configcenter.DynamicConfiguration;
+import org.apache.dubbo.common.logger.Logger;
+import org.apache.dubbo.common.logger.LoggerFactory;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.remoting.etcd.StateListener;
 import org.apache.dubbo.remoting.etcd.jetcd.JEtcdClient;
@@ -48,6 +50,8 @@ import static org.apache.dubbo.common.constants.CommonConstants.PATH_SEPARATOR;
  */
 public class EtcdDynamicConfiguration implements DynamicConfiguration {
 
+    private static final Logger logger = LoggerFactory.getLogger(EtcdDynamicConfiguration.class);
+
     /**
      * The final root path would be: /$NAME_SPACE/config
      */
@@ -71,7 +75,7 @@ public class EtcdDynamicConfiguration implements DynamicConfiguration {
                 try {
                     recover();
                 } catch (Exception e) {
-                    // ignore
+                    logger.error("add etcd watch failed", e);
                 }
             }
         });
@@ -164,7 +168,7 @@ public class EtcdDynamicConfiguration implements DynamicConfiguration {
 
         @Override
         public void onError(Throwable throwable) {
-            // ignore
+            logger.error("etcd watcher get an error", throwable);
         }
 
         @Override

--- a/dubbo-extensions-dependencies-bom/pom.xml
+++ b/dubbo-extensions-dependencies-bom/pom.xml
@@ -121,9 +121,8 @@
         <mina_version>1.1.7</mina_version>
         <slf4j_version>1.7.25</slf4j_version>
         <grizzly_version>2.4.4</grizzly_version>
-        <jetcd_version>0.5.7</jetcd_version>
+        <jetcd_version>0.7.7</jetcd_version>
         <grpc.version>1.53.0</grpc.version>
-        <etcd_launcher_version>0.5.7</etcd_launcher_version>
         <netty4_version>4.1.66.Final</netty4_version>
         <consul_process_version>2.2.1</consul_process_version>
         <consul_version>1.4.2</consul_version>
@@ -410,6 +409,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>io.etcd</groupId>
+                <artifactId>jetcd-test</artifactId>
+                <version>${jetcd_version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-core</artifactId>
                 <version>${grpc.version}</version>
@@ -442,7 +446,7 @@
             <dependency>
                 <groupId>io.etcd</groupId>
                 <artifactId>jetcd-launcher</artifactId>
-                <version>${etcd_launcher_version}</version>
+                <version>${jetcd_version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.github.spotbugs</groupId>

--- a/dubbo-metadata-report-extensions/dubbo-metadata-report-etcd/pom.xml
+++ b/dubbo-metadata-report-extensions/dubbo-metadata-report-etcd/pom.xml
@@ -52,6 +52,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/dubbo-metadata-report-extensions/dubbo-metadata-report-etcd/src/test/java/org/apache/dubbo/metadata/store/etcd/EtcdMetadataReportTest.java
+++ b/dubbo-metadata-report-extensions/dubbo-metadata-report-etcd/src/test/java/org/apache/dubbo/metadata/store/etcd/EtcdMetadataReportTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.dubbo.metadata.store.etcd;
 
+import io.etcd.jetcd.test.EtcdClusterExtension;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.metadata.definition.ServiceDefinitionBuilder;
@@ -30,7 +31,6 @@ import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.launcher.EtcdCluster;
-import io.etcd.jetcd.launcher.EtcdClusterFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +57,7 @@ public class EtcdMetadataReportTest {
 
     private static final String TEST_SERVICE = "org.apache.dubbo.metadata.store.etcd.EtcdMetadata4TstService";
 
-    private EtcdCluster etcdCluster = EtcdClusterFactory.buildCluster(getClass().getSimpleName(), 1, false);
+    private EtcdCluster etcdCluster;
     private Client etcdClientForTest;
     private EtcdMetadataReport etcdMetadataReport;
     private URL registryUrl;
@@ -65,9 +65,13 @@ public class EtcdMetadataReportTest {
 
     @BeforeEach
     public void setUp() {
+        etcdCluster = EtcdClusterExtension.builder().withClusterName(getClass().getSimpleName())
+            .withNodes(1)
+            .withSsl(false)
+            .build().cluster();
         etcdCluster.start();
-        etcdClientForTest = Client.builder().endpoints(etcdCluster.getClientEndpoints()).build();
-        List<URI> clientEndPoints = etcdCluster.getClientEndpoints();
+        etcdClientForTest = Client.builder().endpoints(etcdCluster.clientEndpoints()).build();
+        List<URI> clientEndPoints = etcdCluster.clientEndpoints();
         this.registryUrl = URL.valueOf("etcd://" + clientEndPoints.get(0).getHost() + ":" + clientEndPoints.get(0).getPort());
         etcdMetadataReportFactory = new EtcdMetadataReportFactory();
         this.etcdMetadataReport = (EtcdMetadataReport) etcdMetadataReportFactory.createMetadataReport(registryUrl);
@@ -75,7 +79,9 @@ public class EtcdMetadataReportTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        etcdCluster.close();
+        if (etcdCluster != null) {
+            etcdCluster.stop();
+        }
     }
 
     @Test

--- a/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdCompatibleRegistryFactory.java
+++ b/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdCompatibleRegistryFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.dubbo.registry.etcd;
 
 public class EtcdCompatibleRegistryFactory extends EtcdServiceDiscoveryFactory {

--- a/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdCompatibleRegistryFactory.java
+++ b/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/java/org/apache/dubbo/registry/etcd/EtcdCompatibleRegistryFactory.java
@@ -1,0 +1,12 @@
+package org.apache.dubbo.registry.etcd;
+
+public class EtcdCompatibleRegistryFactory extends EtcdServiceDiscoveryFactory {
+
+    // The extension name of dubbo-registry-etcd is etcd3 and user should config the URL as 'etcd3://localhost:2379'.
+    // But the extension name of dubbo-metadata-report-etcd and dubbo-configcenter-etcd are etcd
+    // and user should config the URL as 'etcd://localhost:2379'.
+    // To avoid confusion for users when configuring URLs in registry, rename the dubbo-registry-etcd extension name
+    // from etcd3 to etcd, and use extend class to compatible the old version of dubbo-registry-etcd.
+    // It can unify the extension name and avoid confusion for users and compatible the old version
+
+}

--- a/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory
+++ b/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory
@@ -1,1 +1,1 @@
-etcd3=org.apache.dubbo.registry.etcd.EtcdRegistryFactory
+etcd=org.apache.dubbo.registry.etcd.EtcdRegistryFactory

--- a/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory
+++ b/dubbo-registry-extensions/dubbo-registry-etcd3/src/main/resources/META-INF/dubbo/internal/org.apache.dubbo.registry.RegistryFactory
@@ -1,1 +1,2 @@
 etcd=org.apache.dubbo.registry.etcd.EtcdRegistryFactory
+etcd3=org.apache.dubbo.registry.etcd.EtcdCompatibleRegistryFactory

--- a/dubbo-registry-extensions/dubbo-registry-etcd3/src/test/java/org/apache/dubbo/registry/etcd/EtcdRegistryTest.java
+++ b/dubbo-registry-extensions/dubbo-registry-etcd3/src/test/java/org/apache/dubbo/registry/etcd/EtcdRegistryTest.java
@@ -95,9 +95,9 @@ public class EtcdRegistryTest {
     URL serviceUrl = URL.valueOf("dubbo://" + NetUtils.getLocalHost() + "/" + service + "?methods=test1,test2");
     URL serviceUrl2 = URL.valueOf("dubbo://" + NetUtils.getLocalHost() + "/" + service + "?methods=test1,test2,test3");
     URL serviceUrl3 = URL.valueOf("dubbo://" + NetUtils.getLocalHost() + "/" + outerService + "?methods=test1,test2");
-    URL registryUrl = URL.valueOf("etcd3://127.0.0.1:2379/org.apache.dubbo.registry.RegistryService");
+    URL registryUrl = URL.valueOf("etcd://127.0.0.1:2379/org.apache.dubbo.registry.RegistryService");
     URL consumerUrl = URL.valueOf("dubbo://" + NetUtils.getLocalHost() + ":2018" + "/" + service + "?methods=test1,test2");
-    RegistryFactory registryFactory = ExtensionLoader.getExtensionLoader(RegistryFactory.class).getExtension("etcd3", false);
+    RegistryFactory registryFactory = ExtensionLoader.getExtensionLoader(RegistryFactory.class).getExtension("etcd", false);
     EtcdRegistry registry;
     URL subscribe = new URL(
             ADMIN_PROTOCOL, NetUtils.getLocalHost(), 0, "",

--- a/dubbo-remoting-extensions/dubbo-remoting-etcd3/pom.xml
+++ b/dubbo-remoting-extensions/dubbo-remoting-etcd3/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>jetcd-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
         </dependency>


### PR DESCRIPTION
## What is the purpose of the change

1. Bump jetcd vertsion from 0.5.7 to 0.7.7
2. Rename the dubbo-registry-etcd extension name from etcd3 to etcd, because the metadata-etcd and configcenter-etcd use the `etcd://127.0.0.1:2379` , the registry address is inconsistent with the other two.

## Brief changelog

1. Bump jetcd vertsion from 0.5.7 to 0.7.7
2. Rename the dubbo-registry-etcd extension name from etcd3 to etcd

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [ ] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
