### PR TITLE
[Dubbo-Spi-Extensions]Fix#14868   The method for adding a listener to a key-value node.

### DIFF
--- a/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/main/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfiguration.java
+++ b/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/main/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfiguration.java
@@ -153,8 +153,17 @@ public class ConsulDynamicConfiguration extends TreePathDynamicConfiguration {
             // Cache notifies all paths with "foo" the root path
             // If you want to watch only "foo" value, you must filter other paths
             Optional<Value> newValue = newValues.values().stream()
-                    .filter(value -> value.getKey().equals(normalizedKey))
-                    .findAny();
+                .filter(value -> {
+                    // Normalize the key: Ensure it's prefixed with "/" if it's not already
+                    String key = value.getKey();
+                    if (!key.startsWith("/")) {
+                        key = "/" + key;  // Add "/" prefix if missing
+                    }
+                    // Check if the normalized key matches the normalizedKey
+                    return key.equals(normalizedKey);
+                })
+                .findAny();
+
 
             newValue.ifPresent(value -> {
                 // Values are encoded in key/value store, decode it if needed

--- a/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
+++ b/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
@@ -93,14 +93,14 @@ public class ConsulDynamicConfigurationTest {
         ConfigurationListener c= event -> {
             //test equals
             assertEquals("value" , event.getContent());
-            assertEquals("/dubbo/config/dubbo/foo" , event.getKey());
+            assertEquals("/dubbo/config/dubbo/abc" , event.getKey());
             assertEquals("dubbo" , event.getGroup());
             assertEquals(ConfigChangeType.MODIFIED , event.getChangeType());
             System.out.println("Test Passed: Configuration change is correct.");
         };
-        configuration.addListener("foo","dubbo",c);
-        kvClient.putValue("/dubbo/config/dubbo/foo", "value");
-        System.out.println(kvClient.getValuesAsString("/dubbo/config/dubbo/foo"));
+        configuration.addListener("abc","dubbo",c);
+        kvClient.putValue("/dubbo/config/dubbo/abc", "value");
+        System.out.println(kvClient.getValuesAsString("/dubbo/config/dubbo/abc"));
     }
 
     @Test

--- a/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
+++ b/dubbo-configcenter-extensions/dubbo-configcenter-consul/src/test/java/org/apache/dubbo/configcenter/consul/ConsulDynamicConfigurationTest.java
@@ -111,10 +111,6 @@ public class ConsulDynamicConfigurationTest {
         Assertions.assertTrue(completed, "Listener event was not triggered in time.");
     }
 
-    @Test
-    public void testRemoveListener() {
-        configuration.removeListener("abc","test",configurationListener);
-    }
 
     @Test
     public void testGetConfigKeys() {


### PR DESCRIPTION
## What is the purpose of the change

Fix#14868:https://github.com/apache/dubbo/issues/14868

## Brief changelog

Added a check in the notify method of the inner class ConsulListener. If the key does not have the "/" prefix, the prefix is added before performing an equals comparison with the normalizedKey. Additionally, the existing unit tests were updated to improve code coverage.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [x] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [x] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
