### PR TITLE
Fix FastJsonObjectInput to support reading object by type

### DIFF
--- a/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/main/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInput.java
@@ -49,11 +49,7 @@ public class FastJsonObjectInput implements DefaultJsonDataInput {
         return readObject(cls, type, null);
     }
 
-    public Object readObject(ParserConfig.AutoTypeCheckHandler handler) throws IOException {
-        return readObject(Object.class, null, handler);
-    }
-
-    private <T> T readObject(Class<T> cls, Type type, ParserConfig.AutoTypeCheckHandler handler) throws IOException {
+    public <T> T readObject(Class<T> cls, Type type, ParserConfig.AutoTypeCheckHandler handler) throws IOException {
         int length = readLength();
         byte[] bytes = new byte[length];
         int read = is.read(bytes, 0, length);
@@ -67,14 +63,23 @@ public class FastJsonObjectInput implements DefaultJsonDataInput {
             parserConfig.addAutoTypeCheckHandler(handler);
         }
 
-        Object result = JSON.parseObject(new String(bytes), cls,
+        Object result;
+        if (cls != null) {
+            result = JSON.parseObject(new String(bytes), cls,
                 parserConfig,
                 Feature.SupportNonPublicField,
                 Feature.SupportAutoType
-        );
-        if (result != null && cls != null && !ClassUtils.isMatch(result.getClass(), cls)) {
-            throw new IllegalArgumentException(
+            );
+            if (result != null && !ClassUtils.isMatch(result.getClass(), cls)) {
+                throw new IllegalArgumentException(
                     "deserialize failed. expected class: " + cls + " but actual class: " + result.getClass());
+            }
+        } else {
+            result = JSON.parseObject(new String(bytes), type,
+                parserConfig,
+                Feature.SupportNonPublicField,
+                Feature.SupportAutoType
+            );
         }
         return (T) result;
 

--- a/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInputOutputTest.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonObjectInputOutputTest.java
@@ -195,7 +195,7 @@ public class FastJsonObjectInputOutputTest {
         fastJsonObjectOutput.flushBuffer();
         pos.close();
 
-        Object result = fastJsonObjectInput.readObject(new TestPojoHandler());
+        Object result = fastJsonObjectInput.readObject(null, null, new TestPojoHandler());
         Assertions.assertNotNull(result);
 
         Assertions.assertEquals("Bob", ((TestPojo) result).getData());

--- a/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonSerializationTest.java
+++ b/dubbo-serialization-extensions/dubbo-serialization-fastjson/src/test/java/org/apache/dubbo/common/serialize/fastjson/FastJsonSerializationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.common.serialize.fastjson;
 
+import com.alibaba.fastjson.TypeReference;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.serialize.ObjectInput;
 import org.apache.dubbo.common.serialize.ObjectOutput;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -82,8 +84,8 @@ class FastJsonSerializationTest {
             byte[] bytes = outputStream.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
-            // this will not throw exception
-            // Assertions.assertThrows(IOException.class, objectInput::readUTF);
+            // Todo should throw exception but return "{}"
+            Assertions.assertEquals("{}", objectInput.readUTF());
         }
 
         // write pojo, read failed
@@ -159,7 +161,7 @@ class FastJsonSerializationTest {
             byte[] bytes = outputStream.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
-            // @Todo this not pass
+            // Todo this not pass: it will not throw IOException but return "{}"
             // Assertions.assertThrows(IOException.class, objectInput::readEvent);
         }
 
@@ -291,7 +293,8 @@ class FastJsonSerializationTest {
             byte[] bytes = outputStream.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
-            Assertions.assertThrows(IOException.class, objectInput::readObject);
+            Type trustedPojoListType = new TypeReference<LinkedList<TrustedPojo>>() {}.getType();
+            Assertions.assertEquals(pojos, objectInput.readObject(null, trustedPojoListType));
         }
 
         // write pojo, read pojo
@@ -324,7 +327,8 @@ class FastJsonSerializationTest {
             byte[] bytes = outputStream.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
-            Assertions.assertThrows(IOException.class, () -> objectInput.readObject(List.class));
+            Type trustedPojoListType = new TypeReference<LinkedList<TrustedPojo>>() {}.getType();
+            Assertions.assertEquals(pojos, objectInput.readObject(null, trustedPojoListType));
         }
 
         // write list, read list
@@ -342,7 +346,8 @@ class FastJsonSerializationTest {
             byte[] bytes = outputStream.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
             ObjectInput objectInput = serialization.deserialize(url, inputStream);
-            Assertions.assertThrows(IOException.class, () -> objectInput.readObject(LinkedList.class));
+            Type trustedPojoListType = new TypeReference<LinkedList<TrustedPojo>>() {}.getType();
+            Assertions.assertEquals(pojos, objectInput.readObject(null, trustedPojoListType));
         }
 
         frameworkModel.destroy();


### PR DESCRIPTION
## What is the purpose of the change
it was impossible to deserialize a ParameterizedType (i.e. contains at least one type parameter and may be an array) by FastJsonObjectInput#readObject(Class<T> cls, Type type) because the type parameter was ignored.

## Brief changelog

XXXXX

## Verifying this change

XXXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/apache/dubbo/issues) field for the change (usually before
  you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address
  just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Format the pull request title like `[Dubbo-XXX] Fix UnknownException when host config not exist #XXX`. Each commit
  in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency
  exist. If the new feature or significant change is committed, please remember to add sample
  in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Run `mvn clean install -DskipTests=false` & `mvn clean test-compile failsafe:integration-test` to make sure
  unit-test and integration-test pass.
- [ ] If this contribution is large, please follow
  the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
